### PR TITLE
Add Button in Settings View to delete API Key

### DIFF
--- a/AIAssistant/AIAssistant.xcodeproj/project.pbxproj
+++ b/AIAssistant/AIAssistant.xcodeproj/project.pbxproj
@@ -388,6 +388,7 @@
 					515B91E32A26306100599B59 = {
 						CreatedOnToolsVersion = 14.3;
 						LastSwiftMigration = 1430;
+						TestTargetID = 5133BD132A33F27000B35668;
 					};
 				};
 			};
@@ -750,6 +751,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = B8AGE2A2NW;
@@ -760,6 +762,7 @@
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AIAssistantMacOSApp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/AIAssistantMacOSApp";
 			};
 			name = Debug;
 		};
@@ -768,6 +771,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = B8AGE2A2NW;
@@ -777,6 +781,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AIAssistantMacOSApp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/AIAssistantMacOSApp";
 			};
 			name = Release;
 		};

--- a/AIAssistant/AIAssistant.xcodeproj/project.pbxproj
+++ b/AIAssistant/AIAssistant.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		51B43FCD2A53BE10007E4013 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51B43FCC2A53BE10007E4013 /* SettingsViewModel.swift */; };
 		51B43FDF2A55117A007E4013 /* Prompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51B43FDE2A55117A007E4013 /* Prompt.swift */; };
 		51B43FE12A5511EA007E4013 /* Completion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51B43FE02A5511EA007E4013 /* Completion.swift */; };
+		51B43FE32A590133007E4013 /* APIKeyDeleter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51B43FE22A590133007E4013 /* APIKeyDeleter.swift */; };
 		51CAA0112A2A7EA70074E577 /* URLSessionHTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51CAA0102A2A7EA70074E577 /* URLSessionHTTPClient.swift */; };
 		51D29B502A3E81B10086EB0E /* ChatViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51D29B4F2A3E81B10086EB0E /* ChatViewModel.swift */; };
 		51D29B522A3E82100086EB0E /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51D29B512A3E82100086EB0E /* ChatView.swift */; };
@@ -97,6 +98,7 @@
 		51B43FCC2A53BE10007E4013 /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
 		51B43FDE2A55117A007E4013 /* Prompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Prompt.swift; sourceTree = "<group>"; };
 		51B43FE02A5511EA007E4013 /* Completion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Completion.swift; sourceTree = "<group>"; };
+		51B43FE22A590133007E4013 /* APIKeyDeleter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIKeyDeleter.swift; sourceTree = "<group>"; };
 		51CAA0102A2A7EA70074E577 /* URLSessionHTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionHTTPClient.swift; sourceTree = "<group>"; };
 		51CAA0142A2A7F5E0074E577 /* AIAssistant.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = AIAssistant.xctestplan; sourceTree = "<group>"; };
 		51CAA0152A2A9DCE0074E577 /* CI.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = CI.xctestplan; sourceTree = "<group>"; };
@@ -253,6 +255,7 @@
 				51D9D3A02A4564130062CE05 /* Infrastructure */,
 				517ECCC32A4D3B030084DE5C /* APIKeyLoader.swift */,
 				517ECCC52A4D3B7B0084DE5C /* APIKeySaver.swift */,
+				51B43FE22A590133007E4013 /* APIKeyDeleter.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -460,6 +463,7 @@
 				5103D3092A279E3400BA4D6B /* PromptSender.swift in Sources */,
 				51D29B502A3E81B10086EB0E /* ChatViewModel.swift in Sources */,
 				517ECCC62A4D3B7B0084DE5C /* APIKeySaver.swift in Sources */,
+				51B43FE32A590133007E4013 /* APIKeyDeleter.swift in Sources */,
 				51CAA0112A2A7EA70074E577 /* URLSessionHTTPClient.swift in Sources */,
 				51B43FE12A5511EA007E4013 /* Completion.swift in Sources */,
 				51B43FCD2A53BE10007E4013 /* SettingsViewModel.swift in Sources */,

--- a/AIAssistant/AIAssistant/Chat/Presentation/SettingsViewModel.swift
+++ b/AIAssistant/AIAssistant/Chat/Presentation/SettingsViewModel.swift
@@ -23,31 +23,45 @@ public class SettingsViewModel: ObservableObject {
         self.apiKeyDeleter = apiKeyDeleter
     }
 
-    public func onAppear() {
+    public func onAppear() async {
         do {
-            openAIApiKey = try apiKeyLoader.load()
+            let loaded = try await apiKeyLoader.load()
+
+            await MainActor.run {
+                openAIApiKey = loaded
+            }
         } catch {
-            errorMessage = "Couldn't load API Key"
+            await MainActor.run {
+                errorMessage = "Couldn't load API Key"
+            }
         }
     }
 
-    public func saveAPIKey() {
+    public func saveAPIKey() async {
         guard !openAIApiKey.isEmpty else {
             return
         }
 
         do {
-            try apiKeySaver.save(openAIApiKey)
+            try await apiKeySaver.save(openAIApiKey)
         } catch {
-            errorMessage = "Couldn't save API Key"
+            await MainActor.run {
+                errorMessage = "Couldn't save API Key"
+            }
         }
     }
 
-    public func deleteAPIKey() {
+    public func deleteAPIKey() async {
         do {
-            try apiKeyDeleter.delete()
+            try await apiKeyDeleter.delete()
+
+            await MainActor.run {
+                openAIApiKey = ""
+            }
         } catch {
-            errorMessage = "Couldn't delete API Key"
+            await MainActor.run {
+                errorMessage = "Couldn't delete API Key"
+            }
         }
     }
 }

--- a/AIAssistant/AIAssistant/Chat/Presentation/SettingsViewModel.swift
+++ b/AIAssistant/AIAssistant/Chat/Presentation/SettingsViewModel.swift
@@ -47,7 +47,7 @@ public class SettingsViewModel: ObservableObject {
         do {
             try apiKeyDeleter.delete()
         } catch {
-            
+            errorMessage = "Couldn't delete API Key"
         }
     }
 }

--- a/AIAssistant/AIAssistant/Chat/Presentation/SettingsViewModel.swift
+++ b/AIAssistant/AIAssistant/Chat/Presentation/SettingsViewModel.swift
@@ -15,10 +15,12 @@ public class SettingsViewModel: ObservableObject {
     }
     private let apiKeyLoader: APIKeyLoader
     private let apiKeySaver: APIKeySaver
+    private let apiKeyDeleter: APIKeyDeleter
 
-    public init(apiKeyLoader: APIKeyLoader, apiKeySaver: APIKeySaver) {
+    public init(apiKeyLoader: APIKeyLoader, apiKeySaver: APIKeySaver, apiKeyDeleter: APIKeyDeleter) {
         self.apiKeyLoader = apiKeyLoader
         self.apiKeySaver = apiKeySaver
+        self.apiKeyDeleter = apiKeyDeleter
     }
 
     public func onAppear() {
@@ -38,6 +40,14 @@ public class SettingsViewModel: ObservableObject {
             try apiKeySaver.save(openAIApiKey)
         } catch {
             errorMessage = "Couldn't save API Key"
+        }
+    }
+
+    public func deleteAPIKey() {
+        do {
+            try apiKeyDeleter.delete()
+        } catch {
+            
         }
     }
 }

--- a/AIAssistant/AIAssistant/Settings/APIKeyDeleter.swift
+++ b/AIAssistant/AIAssistant/Settings/APIKeyDeleter.swift
@@ -6,5 +6,5 @@
 //
 
 public protocol APIKeyDeleter {
-    func delete() throws
+    func delete() async throws
 }

--- a/AIAssistant/AIAssistant/Settings/APIKeyDeleter.swift
+++ b/AIAssistant/AIAssistant/Settings/APIKeyDeleter.swift
@@ -1,0 +1,10 @@
+//
+//  APIKeyDeleter.swift
+//  AIAssistant
+//
+//  Created by Patricio Sepúlveda Heise on 07-07-23.
+//
+
+public protocol APIKeyDeleter {
+    func delete() throws
+}

--- a/AIAssistant/AIAssistant/Settings/APIKeyLoader.swift
+++ b/AIAssistant/AIAssistant/Settings/APIKeyLoader.swift
@@ -6,5 +6,5 @@
 //
 
 public protocol APIKeyLoader {
-    func load() throws -> String
+    func load() async throws -> String
 }

--- a/AIAssistant/AIAssistant/Settings/APIKeySaver.swift
+++ b/AIAssistant/AIAssistant/Settings/APIKeySaver.swift
@@ -6,5 +6,5 @@
 //
 
 public protocol APIKeySaver {
-    func save(_ value: String) throws
+    func save(_ value: String) async throws
 }

--- a/AIAssistant/AIAssistant/Settings/Infrastructure/KeychainAPIKeyStore.swift
+++ b/AIAssistant/AIAssistant/Settings/Infrastructure/KeychainAPIKeyStore.swift
@@ -24,19 +24,6 @@ public class KeychainAPIKeyStore {
         self.key = key
     }
 
-    public func delete() throws {
-        let query: [String: Any] = [
-            String(kSecClass): kSecClassGenericPassword,
-            String(kSecAttrAccount): key
-        ]
-
-        let status = SecItemDelete(query as CFDictionary)
-
-        guard status == noErr else {
-            throw Error.deleteFailure
-        }
-    }
-
     private func add(_ query: [String: Any], _ data: Data) throws {
         let status = SecItemAdd(query as CFDictionary, nil)
         guard status == noErr else {
@@ -97,5 +84,20 @@ extension KeychainAPIKeyStore: APIKeyLoader {
         }
 
         return String(decoding: data, as: UTF8.self)
+    }
+}
+
+extension KeychainAPIKeyStore: APIKeyDeleter {
+    public func delete() throws {
+        let query: [String: Any] = [
+            String(kSecClass): kSecClassGenericPassword,
+            String(kSecAttrAccount): key
+        ]
+
+        let status = SecItemDelete(query as CFDictionary)
+
+        guard status == noErr else {
+            throw Error.deleteFailure
+        }
     }
 }

--- a/AIAssistant/AIAssistant/Settings/Infrastructure/KeychainAPIKeyStore.swift
+++ b/AIAssistant/AIAssistant/Settings/Infrastructure/KeychainAPIKeyStore.swift
@@ -103,7 +103,7 @@ extension KeychainAPIKeyStore: APIKeyDeleter {
 
         let status = SecItemDelete(query as CFDictionary)
 
-        guard status == noErr else {
+        guard status == errSecItemNotFound || status == noErr else {
             throw Error.deleteFailure
         }
     }

--- a/AIAssistant/AIAssistant/Settings/Infrastructure/KeychainAPIKeyStore.swift
+++ b/AIAssistant/AIAssistant/Settings/Infrastructure/KeychainAPIKeyStore.swift
@@ -19,6 +19,7 @@ public actor KeychainAPIKeyStore {
     }
 
     private let key: String
+    private let keychainAccessGroup: String = "B8AGE2A2NW.AIAssistant"
 
     public init(key: String = "com.sepheise.AIAssistant.apiKey") {
         self.key = key
@@ -52,6 +53,8 @@ extension KeychainAPIKeyStore: APIKeySaver {
         let query: [String: Any] = [
             String(kSecClass): kSecClassGenericPassword,
             String(kSecAttrAccount): key,
+            String(kSecAttrAccessGroup): keychainAccessGroup,
+            String(kSecUseDataProtectionKeychain): kCFBooleanTrue as Any,
             String(kSecValueData): data
         ]
         let status = SecItemCopyMatching(query as CFDictionary, nil)
@@ -72,6 +75,8 @@ extension KeychainAPIKeyStore: APIKeyLoader {
         let query = [
             kSecClass: kSecClassGenericPassword,
             kSecAttrAccount: key,
+            kSecAttrAccessGroup: keychainAccessGroup,
+            kSecUseDataProtectionKeychain: kCFBooleanTrue as Any,
             kSecReturnData: kCFBooleanTrue as Any,
             kSecMatchLimit: kSecMatchLimitOne
         ] as CFDictionary
@@ -91,7 +96,9 @@ extension KeychainAPIKeyStore: APIKeyDeleter {
     public func delete() async throws {
         let query: [String: Any] = [
             String(kSecClass): kSecClassGenericPassword,
-            String(kSecAttrAccount): key
+            String(kSecAttrAccount): key,
+            String(kSecAttrAccessGroup): keychainAccessGroup,
+            String(kSecUseDataProtectionKeychain): kCFBooleanTrue as Any
         ]
 
         let status = SecItemDelete(query as CFDictionary)

--- a/AIAssistant/AIAssistant/Settings/Infrastructure/KeychainAPIKeyStore.swift
+++ b/AIAssistant/AIAssistant/Settings/Infrastructure/KeychainAPIKeyStore.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Security
 
-public class KeychainAPIKeyStore {
+public actor KeychainAPIKeyStore {
     public enum Error: Swift.Error {
         case invalidValue
         case saveFailure
@@ -44,7 +44,7 @@ public class KeychainAPIKeyStore {
 }
 
 extension KeychainAPIKeyStore: APIKeySaver {
-    public func save(_ value: String) throws {
+    public func save(_ value: String) async throws {
         guard let data = value.data(using: .utf8) else {
             throw Error.invalidValue
         }
@@ -68,7 +68,7 @@ extension KeychainAPIKeyStore: APIKeySaver {
 }
 
 extension KeychainAPIKeyStore: APIKeyLoader {
-    public func load() throws -> String {
+    public func load() async throws -> String {
         let query = [
             kSecClass: kSecClassGenericPassword,
             kSecAttrAccount: key,
@@ -88,7 +88,7 @@ extension KeychainAPIKeyStore: APIKeyLoader {
 }
 
 extension KeychainAPIKeyStore: APIKeyDeleter {
-    public func delete() throws {
+    public func delete() async throws {
         let query: [String: Any] = [
             String(kSecClass): kSecClassGenericPassword,
             String(kSecAttrAccount): key

--- a/AIAssistant/AIAssistantMacOSApp/AIAssistantMacOSApp.entitlements
+++ b/AIAssistant/AIAssistantMacOSApp/AIAssistantMacOSApp.entitlements
@@ -8,5 +8,9 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)AIAssistant</string>
+	</array>
 </dict>
 </plist>

--- a/AIAssistant/AIAssistantMacOSApp/AIAssistantMacOSApp.swift
+++ b/AIAssistant/AIAssistantMacOSApp/AIAssistantMacOSApp.swift
@@ -56,7 +56,7 @@ private class OpenAIMessageSenderWithKeyLoader: PromptSender {
     }
 
     func send(prompt: AIAssistant.Prompt) async throws -> AIAssistant.PromptResponseStream {
-        guard let apiKey = try? apiKeyLoader.load() else {
+        guard let apiKey = try? await apiKeyLoader.load() else {
             throw Error.cantLoadAPIKey
         }
 

--- a/AIAssistant/AIAssistantMacOSApp/AIAssistantMacOSApp.swift
+++ b/AIAssistant/AIAssistantMacOSApp/AIAssistantMacOSApp.swift
@@ -31,7 +31,8 @@ struct AIAssistantMacOSApp: App {
                 settingsView: SettingsView(
                     viewModel: SettingsViewModel(
                         apiKeyLoader: apiKeyStore,
-                        apiKeySaver: apiKeyStore
+                        apiKeySaver: apiKeyStore,
+                        apiKeyDeleter: apiKeyStore
                     )
                 )
             )

--- a/AIAssistant/AIAssistantMacOSApp/Preview Content/InMemoryAPIKeyStore.swift
+++ b/AIAssistant/AIAssistantMacOSApp/Preview Content/InMemoryAPIKeyStore.swift
@@ -8,7 +8,11 @@
 import AIAssistant
 
 class InMemoryAPIKeyStore: APIKeyLoader, APIKeySaver {
-    var apiKey: String = ""
+    private var apiKey: String
+
+    init(apiKey: String = "") {
+        self.apiKey = apiKey
+    }
 
     func load() throws -> String {
         return apiKey

--- a/AIAssistant/AIAssistantMacOSApp/Preview Content/InMemoryAPIKeyStore.swift
+++ b/AIAssistant/AIAssistantMacOSApp/Preview Content/InMemoryAPIKeyStore.swift
@@ -7,7 +7,7 @@
 
 import AIAssistant
 
-class InMemoryAPIKeyStore: APIKeyLoader, APIKeySaver {
+class InMemoryAPIKeyStore: APIKeyLoader, APIKeySaver, APIKeyDeleter {
     private var apiKey: String
 
     init(apiKey: String = "") {
@@ -20,5 +20,9 @@ class InMemoryAPIKeyStore: APIKeyLoader, APIKeySaver {
 
     func save(_ value: String) throws {
         apiKey = value
+    }
+
+    func delete() throws {
+        apiKey = ""
     }
 }

--- a/AIAssistant/AIAssistantMacOSApp/Views/ContentView.swift
+++ b/AIAssistant/AIAssistantMacOSApp/Views/ContentView.swift
@@ -45,7 +45,8 @@ struct ContentView_Previews: PreviewProvider {
             settingsView: SettingsView(
                 viewModel: SettingsViewModel(
                     apiKeyLoader: inMemoryAPIKeyStore,
-                    apiKeySaver: inMemoryAPIKeyStore
+                    apiKeySaver: inMemoryAPIKeyStore,
+                    apiKeyDeleter: inMemoryAPIKeyStore
                 )
             )
         )

--- a/AIAssistant/AIAssistantMacOSApp/Views/PromptsAndCompletionsView.swift
+++ b/AIAssistant/AIAssistantMacOSApp/Views/PromptsAndCompletionsView.swift
@@ -20,7 +20,9 @@ struct PromptsAndCompletionsView: View {
                         .padding(20)
                         .frame(maxWidth: .infinity, alignment: .topLeading)
                         .background(Color("UserInputBackground"))
-                    Text(LocalizedStringKey(prompt.completion?.content ?? ""))
+
+                    //Text(LocalizedStringKey(prompt.completion?.content ?? ""))
+                    MarkdownTest(text: prompt.completion?.content ?? "")
                         .textSelection(.enabled)
                         .padding(20)
                         .frame(maxWidth: .infinity, alignment: .topLeading)
@@ -38,6 +40,14 @@ struct PromptsAndCompletionsView: View {
                 }
             }
         }
+    }
+}
+
+struct MarkdownTest: View {
+    let text: String
+
+    var body: some View {
+        Text(try! AttributedString(markdown: text))
     }
 }
 

--- a/AIAssistant/AIAssistantMacOSApp/Views/SettingsView.swift
+++ b/AIAssistant/AIAssistantMacOSApp/Views/SettingsView.swift
@@ -17,9 +17,13 @@ struct SettingsView: View {
 
     var body: some View {
         VStack {
-            HStack {
+            HStack(alignment: .center, spacing: 10) {
+                Text("OpenAI API Key")
+
                 TextField("OpenAI API key", text: $viewModel.openAIApiKey)
+                    .submitLabel(.done)
                     .onAppear(perform: viewModel.onAppear)
+                    .textFieldStyle(.roundedBorder)
 
                 Button(
                     action: {
@@ -37,6 +41,7 @@ struct SettingsView: View {
                         .accessibilityHint("Clears api key")
                 }
             }
+            .padding(10)
             Spacer()
         }
         .frame(alignment: .top)
@@ -45,7 +50,7 @@ struct SettingsView: View {
 }
 
 struct SettingsView_Previews: PreviewProvider {
-    private static let inMemoryAPIKeyStore = InMemoryAPIKeyStore()
+    private static let inMemoryAPIKeyStore = InMemoryAPIKeyStore(apiKey: "test key")
 
     static var previews: some View {
         SettingsView(

--- a/AIAssistant/AIAssistantMacOSApp/Views/SettingsView.swift
+++ b/AIAssistant/AIAssistantMacOSApp/Views/SettingsView.swift
@@ -22,12 +22,18 @@ struct SettingsView: View {
 
                 TextField("OpenAI API key", text: $viewModel.openAIApiKey)
                     .submitLabel(.done)
-                    .onAppear(perform: viewModel.onAppear)
                     .textFieldStyle(.roundedBorder)
+                    .onAppear {
+                        Task {
+                            await viewModel.onAppear()
+                        }
+                    }
 
                 Button(
                     action: {
-                        viewModel.saveAPIKey()
+                        Task {
+                            await viewModel.saveAPIKey()
+                        }
                     },
                     label: {
                         Image(systemName: "checkmark")
@@ -36,10 +42,16 @@ struct SettingsView: View {
                 )
                 .disabled(!viewModel.canSave)
 
-                Button(action: {}) {
-                    Image(systemName: "trash.fill")
-                        .accessibilityHint("Clears api key")
-                }
+                Button(
+                    action: {
+                        Task {
+                            await viewModel.deleteAPIKey()
+                        }
+                    },
+                    label: {
+                        Image(systemName: "trash.fill")
+                            .accessibilityHint("Clears api key")
+                    })
             }
             .padding(10)
             Spacer()

--- a/AIAssistant/AIAssistantMacOSApp/Views/SettingsView.swift
+++ b/AIAssistant/AIAssistantMacOSApp/Views/SettingsView.swift
@@ -56,7 +56,8 @@ struct SettingsView_Previews: PreviewProvider {
         SettingsView(
             viewModel: SettingsViewModel(
                 apiKeyLoader: inMemoryAPIKeyStore,
-                apiKeySaver: inMemoryAPIKeyStore
+                apiKeySaver: inMemoryAPIKeyStore,
+                apiKeyDeleter: inMemoryAPIKeyStore
             )
         )
     }

--- a/AIAssistant/AIAssistantTests/Settings/KeychainAPIKeyStoreTests.swift
+++ b/AIAssistant/AIAssistantTests/Settings/KeychainAPIKeyStoreTests.swift
@@ -9,36 +9,57 @@ import XCTest
 import AIAssistant
 
 class KeychainAPIKeyStoreTests: XCTestCase {
-    override func tearDown() {
-        clean()
+    override func tearDown() async throws {
+        try await clean()
     }
 
-    func test_save_doesNotThrowErrorOnValidInput() {
+    func test_save_doesNotThrowErrorOnValidInput() async {
         let anyValue = "any value"
         let sut = makeSUT()
 
-        XCTAssertNoThrow(try sut.save(anyValue))
+        await shouldNotThrow("on valid input") {
+            try await sut.save(anyValue)
+        }
     }
 
-    func test_load_returnsLastSavedValue() {
+    func test_load_returnsLastSavedValue() async {
         let value1 = "first value"
         let value2 = "last value"
         let sut = makeSUT()
 
-        XCTAssertNoThrow(try sut.save(value1))
-        XCTAssertEqual(try sut.load(), value1)
+        await shouldNotThrow("when saving first value") {
+            try await sut.save(value1)
+        }
 
-        XCTAssertNoThrow(try sut.save(value2))
-        XCTAssertEqual(try sut.load(), value2)
+        await shouldNotThrow("when loading first value") {
+            _ = try await sut.load()
+        }
+
+        await shouldNotThrow("when saving second value") {
+            try await sut.save(value2)
+        }
+
+        var loadedValue2: String = ""
+
+        await shouldNotThrow("when loading second value") {
+            loadedValue2 = try await sut.load()
+        }
+
+        XCTAssertEqual(loadedValue2, value2)
     }
 
-    func test_delete_removesSavedValue() throws {
+    func test_delete_removesSavedValue() async throws {
         let sut = makeSUT()
 
-        try sut.save("any value")
+        try await sut.save("any value")
 
-        XCTAssertNoThrow(try sut.delete())
-        XCTAssertThrowsError(try sut.load())
+        await shouldNotThrow("on delete") {
+            try await sut.delete()
+        }
+
+        await shouldThrow("on load") {
+            _ = try await sut.load()
+        }
     }
 
     // MARK: - Helpers
@@ -48,9 +69,24 @@ class KeychainAPIKeyStoreTests: XCTestCase {
         return sut
     }
 
-    private func clean() {
+    private func clean() async throws {
         do {
-            try KeychainAPIKeyStore().delete()
+            try await KeychainAPIKeyStore().delete()
+        } catch {}
+    }
+
+    private func shouldNotThrow(_ message: String, action: () async throws -> Void) async {
+        do {
+            try await action()
+        } catch {
+            XCTFail("Shouldn't throw error \(message)")
+        }
+    }
+
+    private func shouldThrow(_ message: String, action: () async throws -> Void) async {
+        do {
+            try await action()
+            XCTFail("Should throw error \(message)")
         } catch {}
     }
 }

--- a/AIAssistant/AIAssistantTests/Settings/KeychainAPIKeyStoreTests.swift
+++ b/AIAssistant/AIAssistantTests/Settings/KeychainAPIKeyStoreTests.swift
@@ -9,8 +9,10 @@ import XCTest
 import AIAssistant
 
 class KeychainAPIKeyStoreTests: XCTestCase {
+    private let keychainKey = "com.sepheise.AIAssistant.tests"
+
     override func tearDown() async throws {
-        try await clean()
+        //try await clean()
     }
 
     func test_save_doesNotThrowErrorOnValidInput() async {
@@ -58,21 +60,20 @@ class KeychainAPIKeyStoreTests: XCTestCase {
         }
 
         await shouldThrow("on load") {
-            _ = try await sut.load()
+            let loaded = try await sut.load()
+            XCTAssertEqual(loaded, "")
         }
     }
 
     // MARK: - Helpers
 
     private func makeSUT() -> KeychainAPIKeyStore {
-        let sut = KeychainAPIKeyStore(key: "com.sepheise.AIAssistant.tests")
+        let sut = KeychainAPIKeyStore(key: keychainKey)
         return sut
     }
 
     private func clean() async throws {
-        do {
-            try await KeychainAPIKeyStore().delete()
-        } catch {}
+        try await makeSUT().delete()
     }
 
     private func shouldNotThrow(_ message: String, action: () async throws -> Void) async {

--- a/AIAssistant/AIAssistantTests/Settings/KeychainAPIKeyStoreTests.swift
+++ b/AIAssistant/AIAssistantTests/Settings/KeychainAPIKeyStoreTests.swift
@@ -12,7 +12,7 @@ class KeychainAPIKeyStoreTests: XCTestCase {
     private let keychainKey = "com.sepheise.AIAssistant.tests"
 
     override func tearDown() async throws {
-        //try await clean()
+        try await clean()
     }
 
     func test_save_doesNotThrowErrorOnValidInput() async {

--- a/AIAssistant/AIAssistantTests/Settings/SettingsViewModelTests.swift
+++ b/AIAssistant/AIAssistantTests/Settings/SettingsViewModelTests.swift
@@ -84,6 +84,17 @@ class SettingsViewModelTests: XCTestCase {
         XCTAssertEqual(deleterSpy.deleteCallsCount, 1)
     }
 
+    func test_delete_setsErrorMessageOnDeleteFailure() {
+        let deleterSpy = APIKeyDeleterSpy(result: .failure(anyError()))
+        let sut = makeSUT(apiKeyDeleterSpy: deleterSpy)
+
+        sut.openAIApiKey = "any key"
+        sut.deleteAPIKey()
+
+        XCTAssertEqual(deleterSpy.deleteCallsCount, 1)
+        XCTAssertEqual(sut.errorMessage, "Couldn't delete API Key")
+    }
+
     // MARK: - Helpers
 
     func makeSUT(


### PR DESCRIPTION
- Convert KeychainStore to an actor, to be able to run operations outside of the main thread while continue updating state in that thread.
- Fix clean test key on Tests tear down method